### PR TITLE
fsType fix

### DIFF
--- a/sources/2-build/Bungee_Basic/Bungee-Hairline.ufo/fontinfo.plist
+++ b/sources/2-build/Bungee_Basic/Bungee-Hairline.ufo/fontinfo.plist
@@ -99,7 +99,6 @@
     </array>
     <key>openTypeOS2Type</key>
     <array>
-      <integer>0</integer>
     </array>
     <key>openTypeOS2VendorID</key>
     <string>djr </string>

--- a/sources/2-build/Bungee_Basic/Bungee-Inline.ufo/fontinfo.plist
+++ b/sources/2-build/Bungee_Basic/Bungee-Inline.ufo/fontinfo.plist
@@ -89,7 +89,6 @@
     </array>
     <key>openTypeOS2Type</key>
     <array>
-      <integer>0</integer>
     </array>
     <key>openTypeOS2VendorID</key>
     <string>djr </string>

--- a/sources/2-build/Bungee_Basic/Bungee-Outline.ufo/fontinfo.plist
+++ b/sources/2-build/Bungee_Basic/Bungee-Outline.ufo/fontinfo.plist
@@ -89,7 +89,6 @@
     </array>
     <key>openTypeOS2Type</key>
     <array>
-      <integer>0</integer>
     </array>
     <key>openTypeOS2VendorID</key>
     <string>djr </string>

--- a/sources/2-build/Bungee_Basic/Bungee-Shade.ufo/fontinfo.plist
+++ b/sources/2-build/Bungee_Basic/Bungee-Shade.ufo/fontinfo.plist
@@ -89,7 +89,6 @@
     </array>
     <key>openTypeOS2Type</key>
     <array>
-      <integer>0</integer>
     </array>
     <key>openTypeOS2VendorID</key>
     <string>djr </string>

--- a/sources/2-build/Bungee_Color/Bungee_Color-Regular.ufo/fontinfo.plist
+++ b/sources/2-build/Bungee_Color/Bungee_Color-Regular.ufo/fontinfo.plist
@@ -99,7 +99,6 @@
     </array>
     <key>openTypeOS2Type</key>
     <array>
-      <integer>0</integer>
     </array>
     <key>openTypeOS2VendorID</key>
     <string>djr </string>

--- a/sources/2-build/Bungee_Layers/Bungee_Layers-Inline.ufo/fontinfo.plist
+++ b/sources/2-build/Bungee_Layers/Bungee_Layers-Inline.ufo/fontinfo.plist
@@ -99,7 +99,6 @@
     </array>
     <key>openTypeOS2Type</key>
     <array>
-      <integer>0</integer>
     </array>
     <key>openTypeOS2VendorID</key>
     <string>djr </string>

--- a/sources/2-build/Bungee_Layers/Bungee_Layers-Outline.ufo/fontinfo.plist
+++ b/sources/2-build/Bungee_Layers/Bungee_Layers-Outline.ufo/fontinfo.plist
@@ -99,7 +99,6 @@
     </array>
     <key>openTypeOS2Type</key>
     <array>
-      <integer>0</integer>
     </array>
     <key>openTypeOS2VendorID</key>
     <string>djr </string>

--- a/sources/2-build/Bungee_Layers/Bungee_Layers-Regular.ufo/fontinfo.plist
+++ b/sources/2-build/Bungee_Layers/Bungee_Layers-Regular.ufo/fontinfo.plist
@@ -99,7 +99,6 @@
     </array>
     <key>openTypeOS2Type</key>
     <array>
-      <integer>0</integer>
     </array>
     <key>openTypeOS2VendorID</key>
     <string>djr </string>

--- a/sources/2-build/Bungee_Layers/Bungee_Layers-Shade.ufo/fontinfo.plist
+++ b/sources/2-build/Bungee_Layers/Bungee_Layers-Shade.ufo/fontinfo.plist
@@ -99,7 +99,6 @@
     </array>
     <key>openTypeOS2Type</key>
     <array>
-      <integer>0</integer>
     </array>
     <key>openTypeOS2VendorID</key>
     <string>djr </string>

--- a/sources/2-build/Bungee_Layers_Rotated/Bungee_Layers_Rotated-Inline.ufo/fontinfo.plist
+++ b/sources/2-build/Bungee_Layers_Rotated/Bungee_Layers_Rotated-Inline.ufo/fontinfo.plist
@@ -99,7 +99,6 @@
     </array>
     <key>openTypeOS2Type</key>
     <array>
-      <integer>0</integer>
     </array>
     <key>openTypeOS2VendorID</key>
     <string>djr </string>

--- a/sources/2-build/Bungee_Layers_Rotated/Bungee_Layers_Rotated-Outline.ufo/fontinfo.plist
+++ b/sources/2-build/Bungee_Layers_Rotated/Bungee_Layers_Rotated-Outline.ufo/fontinfo.plist
@@ -99,7 +99,6 @@
     </array>
     <key>openTypeOS2Type</key>
     <array>
-      <integer>0</integer>
     </array>
     <key>openTypeOS2VendorID</key>
     <string>djr </string>

--- a/sources/2-build/Bungee_Layers_Rotated/Bungee_Layers_Rotated-Regular.ufo/fontinfo.plist
+++ b/sources/2-build/Bungee_Layers_Rotated/Bungee_Layers_Rotated-Regular.ufo/fontinfo.plist
@@ -99,7 +99,6 @@
     </array>
     <key>openTypeOS2Type</key>
     <array>
-      <integer>0</integer>
     </array>
     <key>openTypeOS2VendorID</key>
     <string>djr </string>

--- a/sources/2-build/Bungee_Layers_Rotated/Bungee_Layers_Rotated-Shade.ufo/fontinfo.plist
+++ b/sources/2-build/Bungee_Layers_Rotated/Bungee_Layers_Rotated-Shade.ufo/fontinfo.plist
@@ -99,7 +99,6 @@
     </array>
     <key>openTypeOS2Type</key>
     <array>
-      <integer>0</integer>
     </array>
     <key>openTypeOS2VendorID</key>
     <string>djr </string>


### PR DESCRIPTION
Hi @djrrb,

This PR changes the fsType value to `0` to set it as "installable embedding" following what was reported and discussed in [this issue](https://github.com/google/fonts/issues/5724).