### PR TITLE
Misc fontbakery fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fontbakery[googlefonts]==0.12.3
+fontbakery[googlefonts]==0.12.5
 fontmake==3.9.0
 gftools==0.9.54
 nanoemoji==0.15.1

--- a/sources/1-drawing/Bungee-Regular.ufo/fontinfo.plist
+++ b/sources/1-drawing/Bungee-Regular.ufo/fontinfo.plist
@@ -83,9 +83,10 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://www.djr.com</string>
     <key>openTypeNameLicense</key>
-    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://scripts.sil.org/OFL</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is available with a FAQ at: openfontlicense.org</string>
     <key>openTypeNameLicenseURL</key>
-    <string>https://scripts.sil.org/OFL</string>
+    <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>
     <string>David Jonathan Ross</string>
     <key>openTypeNameManufacturerURL</key>

--- a/sources/1-drawing/Bungee-Regular.ufo/fontinfo.plist
+++ b/sources/1-drawing/Bungee-Regular.ufo/fontinfo.plist
@@ -83,7 +83,7 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://www.djr.com</string>
     <key>openTypeNameLicense</key>
-    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: openfontlicense.org</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: https://openfontlicense.org</string>
     <key>openTypeNameLicenseURL</key>
     <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>

--- a/sources/1-drawing/Bungee-Regular.ufo/fontinfo.plist
+++ b/sources/1-drawing/Bungee-Regular.ufo/fontinfo.plist
@@ -83,8 +83,7 @@
     <key>openTypeNameDesignerURL</key>
     <string>https://www.djr.com</string>
     <key>openTypeNameLicense</key>
-    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1.
-This license is available with a FAQ at: openfontlicense.org</string>
+    <string>This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: openfontlicense.org</string>
     <key>openTypeNameLicenseURL</key>
     <string>https://openfontlicense.org</string>
     <key>openTypeNameManufacturer</key>

--- a/sources/1-drawing/Bungee-Regular.ufo/glyphs/brevebelowcmb.glif
+++ b/sources/1-drawing/Bungee-Regular.ufo/glyphs/brevebelowcmb.glif
@@ -2,6 +2,7 @@
 <glyph name="brevebelowcmb" format="2">
   <advance height="1000"/>
   <unicode hex="032E"/>
+  <anchor x="0" y="-21" name="_bottom"/>
   <outline>
     <component base="breve" xOffset="-250" yOffset="-1020"/>
   </outline>

--- a/sources/1-drawing/Bungee-Regular.ufo/glyphs/commaturnedabovecmb.glif
+++ b/sources/1-drawing/Bungee-Regular.ufo/glyphs/commaturnedabovecmb.glif
@@ -2,6 +2,7 @@
 <glyph name="commaturnedabovecmb" format="2">
   <advance height="1000"/>
   <unicode hex="0312"/>
+  <anchor x="0" y="381" name="_top"/>
   <outline>
     <component base="commaturnedmod" xOffset="-250"/>
   </outline>

--- a/sources/1-drawing/Bungee-Regular.ufo/glyphs/dieresisbelowcmb.glif
+++ b/sources/1-drawing/Bungee-Regular.ufo/glyphs/dieresisbelowcmb.glif
@@ -2,6 +2,7 @@
 <glyph name="dieresisbelowcmb" format="2">
   <advance height="1000"/>
   <unicode hex="0324"/>
+  <anchor x="0" y="-21" name="_bottom"/>
   <outline>
     <component base="dieresiscmb" yOffset="-987"/>
   </outline>

--- a/sources/1-drawing/Bungee-Regular.ufo/glyphs/dotbelowcmb.glif
+++ b/sources/1-drawing/Bungee-Regular.ufo/glyphs/dotbelowcmb.glif
@@ -2,6 +2,7 @@
 <glyph name="dotbelowcmb" format="2">
   <advance height="1000"/>
   <unicode hex="0323"/>
+  <anchor x="0" y="-21" name="_bottom"/>
   <outline>
     <component base="dotaccent" xOffset="-251" yOffset="-1000"/>
   </outline>

--- a/sources/1-drawing/Bungee-Regular.ufo/glyphs/hookcmb.glif
+++ b/sources/1-drawing/Bungee-Regular.ufo/glyphs/hookcmb.glif
@@ -2,6 +2,7 @@
 <glyph name="hookcmb" format="2">
   <advance height="1000"/>
   <unicode hex="0309"/>
+  <anchor x="0" y="747" name="_top"/>
   <outline>
     <contour>
       <point x="99" y="767" type="line" smooth="yes"/>

--- a/sources/1-drawing/Bungee-Regular.ufo/glyphs/horncmb.glif
+++ b/sources/1-drawing/Bungee-Regular.ufo/glyphs/horncmb.glif
@@ -2,6 +2,7 @@
 <glyph name="horncmb" format="2">
   <advance height="1000"/>
   <unicode hex="031B"/>
+  <anchor x="-124" y="652" name="_horn"/>
   <outline>
     <contour>
       <point x="93" y="721" type="curve"/>

--- a/sources/1-drawing/Bungee-Regular.ufo/glyphs/hyphen.glif
+++ b/sources/1-drawing/Bungee-Regular.ufo/glyphs/hyphen.glif
@@ -2,7 +2,6 @@
 <glyph name="hyphen" format="2">
   <advance height="1000" width="420"/>
   <unicode hex="002D"/>
-  <unicode hex="00AD"/>
   <unicode hex="2010"/>
   <outline>
     <contour>

--- a/sources/1-drawing/Bungee-Regular.ufo/glyphs/macron.glif
+++ b/sources/1-drawing/Bungee-Regular.ufo/glyphs/macron.glif
@@ -2,7 +2,6 @@
 <glyph name="macron" format="2">
   <advance height="1000" width="500"/>
   <unicode hex="00AF"/>
-  <unicode hex="0304"/>
   <outline>
     <component base="macroncmb" xOffset="250"/>
   </outline>

--- a/sources/1-drawing/Bungee-Regular.ufo/glyphs/macronbelowcmb.glif
+++ b/sources/1-drawing/Bungee-Regular.ufo/glyphs/macronbelowcmb.glif
@@ -2,6 +2,7 @@
 <glyph name="macronbelowcmb" format="2">
   <advance height="1000"/>
   <unicode hex="0331"/>
+  <anchor x="0" y="-21" name="_bottom"/>
   <outline>
     <component base="macron" xOffset="-249" yOffset="-965"/>
   </outline>

--- a/sources/1-drawing/Bungee-Regular.ufo/glyphs/macroncmb.glif
+++ b/sources/1-drawing/Bungee-Regular.ufo/glyphs/macroncmb.glif
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="macroncmb" format="2">
   <advance height="1000"/>
+  <unicode hex="0304"/>
   <anchor x="0.0" y="747" name="_top"/>
   <anchor x="0.0" y="0" name="_bottom"/>
   <anchor x="0" y="953" name="top"/>

--- a/sources/1-drawing/Bungee-Regular.ufo/lib.plist
+++ b/sources/1-drawing/Bungee-Regular.ufo/lib.plist
@@ -8019,5 +8019,16 @@
       <string>periodcentered.v</string>
       <string>commaturnedabovecmb</string>
     </array>
+    <key>public.openTypeMeta</key>
+    <dict>
+      <key>dlng</key>
+      <array>
+        <string>Latn</string>
+      </array>
+      <key>slng</key>
+      <array>
+        <string>Latn</string>
+      </array>
+    </dict>
   </dict>
 </plist>


### PR DESCRIPTION
This fixes #110:
- update license description and URL
- remove code point for soft hyphen
- fix glyph assignment for combining macron: U+0304 now uses `macroncmb`
- add `_` anchors to reported combining marks, hoping they will end up in GDEF
- add minimal definition for the meta table