### PR TITLE
Updates the OFL license url

### DIFF
--- a/OFL.txt
+++ b/OFL.txt
@@ -2,7 +2,7 @@ Copyright 2023 The Bungee Project Authors (https://github.com/djrrb/Bungee)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:
-https://scripts.sil.org/OFL
+https://openfontlicense.org
 
 
 -----------------------------------------------------------


### PR DESCRIPTION
@djrrb This PR updates the license URL in the OFL, matching what the `v2.000` fonts already have in the name table :)