### PR TITLE
Copy meta table info from source font

### DIFF
--- a/scripts/assembleRotatedSources.py
+++ b/scripts/assembleRotatedSources.py
@@ -171,6 +171,7 @@ def main():
             delattr(outputFont.info, fieldName)
         outputFont.info.familyName = familyName
         outputFont.lib["public.glyphOrder"] = glyphOrder
+        outputFont.lib["public.openTypeMeta"] = regularSourceFont.lib["public.openTypeMeta"]
         outputFont.groups = rotatedSourceFont.groups
         outputFont.kerning = rotatedSourceFont.kerning
         outputFont.features.text = fixFeatureIncludes(rotatedSourceFont.features.text)

--- a/scripts/assembleSources.py
+++ b/scripts/assembleSources.py
@@ -39,6 +39,7 @@ def breakOutLayers(familyName, source, style, outputPath):
     newFont.info.familyName = familyName
     newFont.info.styleName = styleName
     newFont.lib["public.glyphOrder"] = sourceFont.lib["public.glyphOrder"]
+    newFont.lib["public.openTypeMeta"] = sourceFont.lib["public.openTypeMeta"]
     newFont.kerning = sourceFont.kerning
     newFont.groups = sourceFont.groups
     newFont.features.text = fixFeatureIncludes(sourceFont.features.text)


### PR DESCRIPTION
The meta table info was available in the source UFO, but got lost during layer assembly. This fixes half of #116.

This is a followup to https://github.com/djrrb/Bungee/commit/8b2f2481d0a1e2e5c07f8683a29705ac8e8369b8.